### PR TITLE
Add collections

### DIFF
--- a/lib/wholable/collection.rb
+++ b/lib/wholable/collection.rb
@@ -1,0 +1,5 @@
+module Wholable
+  module Collection
+    def self.[](...) = EquatableCollection.new(...)
+  end
+end

--- a/lib/wholable/equatable_collection.rb
+++ b/lib/wholable/equatable_collection.rb
@@ -1,0 +1,56 @@
+module Wholable
+  class EquatableCollection < Equatable
+    def included(descendant)
+      define_class_methods(descendant)
+      super(descendant)
+    end
+
+    private
+
+    def define_class_methods(descendant)
+      define_definer(descendant)
+      define_all(descendant)
+      define_field_collections(descendant)
+      define_finder(descendant)
+    end
+
+    def define_definer(descendant)
+      descendant.class_eval <<~DEFINER, __FILE__, __LINE__ + 1
+        def self.define(symbol, instance)
+          constant = const_set(symbol.to_s.upcase, instance)
+          self.all << constant
+        end
+      DEFINER
+    end
+
+    def define_all(descendant)
+      descendant.class_eval <<~ALL, __FILE__, __LINE__ + 1
+        def self.all
+          @_all ||= []
+        end
+      ALL
+    end
+
+    def define_field_collections(descendant)
+      descendant.members.each do |field|
+        define_field_collection(descendant, field)
+      end
+    end
+
+    def define_field_collection(descendant, field)
+      descendant.class_eval <<~FIELD_COLLECTION, __FILE__, __LINE__ + 1
+        def self.#{field}s
+          all.map(&:#{field})
+        end
+      FIELD_COLLECTION
+    end
+
+    def define_finder(descendant)
+      descendant.class_eval <<~FINDER, __FILE__, __LINE__ + 1
+        def self.find_by(field:, value:)
+          all.find { |instance| instance.send(field) == value }
+        end
+      FINDER
+    end
+  end
+end


### PR DESCRIPTION
## Overview

I have a codebase that has lots of collections of value objects, and I was wondering if something like this might be useful. I'm testing this out in my codebase to see if I like it, wondering what you think. 

## Details

An example of usage, the `DegreeCaught` is has the description that is stored in the db in a column on a record, but the weight is its display order in the drop down, and for other comparison reasons.  And the `DegreeCaught::COMPLETELY_BURIED` and similar constants are needed elswhere in the codebase for other business logic and validation purposes.

```ruby
class DegreeCaught < Struct.new(:key, :description, :weight, keyword_init: true)
  include Wholable::Collection[*self.members.map(&:to_sym)]

  define :NONE, new(key: :none, description: "None", weight: 0)
  define :UNKNOWN, new(key: :unknown, description: "Unknown", weight: 1)
  define :TRIGGERED_NOT_CAUGHT, new(key: :triggered_not_caught, description: "Triggered - not caught", weight: 2)
  define :CAUGHT_NOT_BURIED, new(key: :caught_not_buried, description: "Caught - not buried", weight: 3)
  define :PARTIALLY_BURIED_NOT_CRITICAL, new(key: :partially_buried_not_critical, description: "Partially buried - not critical", weight: 4)
  define :PARTIALLY_BURIED_CRITICAL, new(key: :partially_buried_critical, description: "Partially buried - critical", weight: 5)
  define :COMPLETELY_BURIED, new(key: :completely_buried, description: "Completely buried", weight: 6)
end
```

